### PR TITLE
add ability for admin to change change status

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,7 +13,11 @@ class SessionsController < ApplicationController
         else
           cookies[:auth_token] = user.auth_token
         end
-        redirect_to root_url, :notice => "Logged in!"
+        if user.is_admin?
+          redirect_to users_path, :notice => "Logged in!"
+        else
+          redirect_to root_url, :notice => "Logged in!"
+        end
       else
         flash.now.alert = "Invalid email or password"
         render "new"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[ show edit update applied_to_submitted]
+  before_action :set_user, only: %i[ show edit update change_profile_status]
   before_action :authorize, only: :index
 
   def index
@@ -52,13 +52,16 @@ class UsersController < ApplicationController
     end
   end
 
-  #change users profile status from applied to submitted
-  def applied_to_submitted
-    @user.profile_status = 1
-    # UserMailer.with(user: @user).new_user_registration.deliver_now
+  def change_profile_status
+    new_status = params[:status]
+    @user.profile_status = new_status.to_i
+    @user.save
+    if current_user.is_admin?
+      redirect_to users_path, notice: "Status for " + @user.first_name + " changed to " +  User.profile_statuses.key(new_status.to_i)
+    else
+      redirect_to root_url, notice: "Status for " + @user.first_name + " changed to " +  User.profile_statuses.key(new_status.to_i)
+    end
   end
-
-
 
   private
     # Use callbacks to share common setup or constraints between actions.

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -6,6 +6,7 @@
   <thead>
     <tr>
       <th>Email</th>
+      <th>First Name</th>
       <th>Last Name</th>
       <th>Zip Code</th>
       <th>City</th>
@@ -19,6 +20,7 @@
     <% @users.each do |user| %>
       <tr>
         <td><%= user.email %></td>
+        <td><%= user.first_name %></td>
         <td><%= user.last_name %></td>
         <td><%= user.zip_code %></td>
         <td><%= user.city %></td>
@@ -37,4 +39,3 @@
 
 <br>
 
-<%= link_to 'New user', new_user_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -77,19 +77,19 @@ This is the show view
   <%= @user.prework_repo_link %>
 </p>
 
-<%# <%= link_to 'Edit', edit_user_path(@user) %>
-
-
-
-<%# <% add drop-down menu so Admin has options IOT change profile_status  %>
-<%# and this functionality needs a button to change appropriate status %>
-<%# wire one up and then other will follow %>
-
-<%# <%= select_tag 'User', options_from_collection_for_select(:current_user, 'id', 'profile_status')%>
-
+<p>
+<%= link_to 'Edit', edit_user_path(@user) %>
+</p>
 
 <% if current_user.is_admin? %>
+  <p>
+  <%= form_tag change_profile_status_path(id: @user.id), method: :post do %>
+    <%= select_tag :status, options_for_select(User.profile_statuses.map {|k, v| [k.humanize.capitalize, v]}) %>
+    <%= submit_tag "Change Status" %>
+  <% end %>
+  </p>
   <%= link_to 'Back to list of Recruits', users_path %>
 <% else %>
-  <%= button_to 'Submit for Review', applied_to_submitted_path(id: current_user.id) , method: :post %>
+  Your current status is <%= @user.profile_status %>
+  <%= button_to 'Submit for Review', change_profile_status_path(id: @user.id, status: 1) , method: :post %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   get 'welcome', to: 'sessions#welcome', as: 'welcome'
 
 
-  post 'applied_to_submitted', to: 'users#applied_to_submitted'
+  post 'change_profile_status', to: 'users#change_profile_status'
 
   root to: "sessions#welcome"
 


### PR DESCRIPTION
@gacurl this should take care of the basic functionality for https://github.com/Vets-Who-Code/recruit_tracker/issues/12 but we still need email notifications to admins and user when a status changes and validation so recruit can't change status to submitted until their profile is complete.